### PR TITLE
Add shared operation map

### DIFF
--- a/amplify/functions/aiDispatcher/handler.ts
+++ b/amplify/functions/aiDispatcher/handler.ts
@@ -1,6 +1,7 @@
 // amplify/functions/aiDispatcher/handler.ts
 import { Logger } from "@aws-lambda-powertools/logger";
 import { AIOperation } from '../providers/IAIProvider';
+import { OPERATION_MAP } from '../providers/operationMap';
 import RunwayML from '@runwayml/sdk';
 
 // Initialize the logger
@@ -48,6 +49,11 @@ export const handler = async (event: any) => {
 
     const operation = event.arguments.operation;
     const providerName = event.arguments.provider || "replicate";
+
+    if (!OPERATION_MAP[providerName] ||
+        !OPERATION_MAP[providerName].includes(operation as AIOperation)) {
+        throw new Error(`Operation ${operation} not supported for provider ${providerName}`);
+    }
 
     try {
         logger.debug('Creating provider instance', { provider: providerName });

--- a/amplify/functions/providers/operationMap.ts
+++ b/amplify/functions/providers/operationMap.ts
@@ -1,0 +1,13 @@
+import type { AIOperation } from './IAIProvider';
+
+/**
+ * Map of provider names to the operations they support.
+ */
+export const OPERATION_MAP: Record<string, AIOperation[]> = {
+    replicate: ['generateImage', 'upscaleImage'],
+    stability: ['generateImage', 'upscaleImage', 'outpaint', 'styleTransfer'],
+    gemini: ['generateImage', 'inpaint'],
+    runway: ['generateVideo'],
+};
+
+export type ProviderName = keyof typeof OPERATION_MAP;

--- a/components/OperationSelector.tsx
+++ b/components/OperationSelector.tsx
@@ -1,4 +1,5 @@
 import { AIOperation } from '@/amplify/functions/providers/IAIProvider';
+import { OPERATION_MAP } from '@/amplify/functions/providers/operationMap';
 import styles from "./OperationSelector.module.css";
 
 interface OperationSelectorProps {
@@ -7,16 +8,10 @@ interface OperationSelectorProps {
     provider: string;
 }
 
-// Map of supported operations by provider
-export const PROVIDER_OPERATIONS: Record<string, AIOperation[]> = {
-    replicate: ['upscaleImage'],
-    stability: ['upscaleImage', 'outpaint'],
-    gemini: ['inpaint']
-};
 
 export default function OperationSelector({ value, onChange, provider }: OperationSelectorProps) {
     // Get operations supported by the current provider
-    const supportedOperations = PROVIDER_OPERATIONS[provider] || ['upscaleImage'];
+    const supportedOperations = OPERATION_MAP[provider] || ['upscaleImage'];
 
     // Map operations to user-friendly labels
     const operationLabels: Record<string, string> = {

--- a/pages/edit-image.tsx
+++ b/pages/edit-image.tsx
@@ -6,7 +6,8 @@ import CustomCompareSlider from "@/components/CustomCompareSlider";
 import ProviderSelector from "@/components/ProviderSelector";
 import { createProvider } from '@/amplify/functions/providers/providerFactory';
 import { saveImageRecord } from "@/utils/saveImageRecord";
-import OperationSelector, { PROVIDER_OPERATIONS } from '@/components/OperationSelector';
+import OperationSelector from '@/components/OperationSelector';
+import { OPERATION_MAP } from '@/amplify/functions/providers/operationMap';
 import { AIOperation } from "@/amplify/functions/providers/IAIProvider";
 import { useImageOperation } from '@/components/ImageOperations/useImageOperation';
 import styles from "./EditImage.module.css";
@@ -61,7 +62,7 @@ export default function EditImagePage() {
     const handleProviderChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const newProvider = e.target.value;
         setProvider(newProvider);
-        const supportedOps = PROVIDER_OPERATIONS[newProvider] || [];
+        const supportedOps = OPERATION_MAP[newProvider] || [];
         if (supportedOps.length > 0 && !supportedOps.includes(operation)) {
             setOperation(supportedOps[0]);
         }


### PR DESCRIPTION
## Summary
- centralize provider operation mapping in `operationMap.ts`
- use OPERATION_MAP in `OperationSelector` and `edit-image`
- validate operations in `aiDispatcher` using the shared map

## Testing
- `npm run lint` *(fails: `next` not found)*