### PR TITLE
Add shared logger and replace console statements

### DIFF
--- a/amplify/functions/providers/geminiProvider.ts
+++ b/amplify/functions/providers/geminiProvider.ts
@@ -2,6 +2,7 @@
 import { GoogleGenAI } from '@google/genai';
 import { IAIProvider, AIOperation, ProviderMetadata, ModelMetadata } from './IAIProvider';
 import axios from 'axios';
+import logger from '../../utils/logger';
 
 export class GeminiProvider implements IAIProvider {
     getProviderInfo(): ProviderMetadata {
@@ -44,12 +45,18 @@ export class GeminiProvider implements IAIProvider {
             });
             if (!response.candidates || response.candidates.length === 0) {
                 // Log the raw response for debugging purposes
-                console.error("No candidates returned from Gemini. Full response:", JSON.stringify(response));
+                logger.error(
+                    "No candidates returned from Gemini. Full response:",
+                    JSON.stringify(response)
+                );
                 throw new Error("No candidates returned from Gemini");
             }
             const candidate = response.candidates[0];
             if (!candidate.content || !candidate.content.parts || candidate.content.parts.length === 0) {
-                console.error("No content parts in candidate. Full candidate:", JSON.stringify(candidate));
+                logger.error(
+                    "No content parts in candidate. Full candidate:",
+                    JSON.stringify(candidate)
+                );
                 throw new Error("No content parts found in Gemini candidate");
             }
             for (const part of candidate.content.parts) {
@@ -59,7 +66,7 @@ export class GeminiProvider implements IAIProvider {
             }
             throw new Error("No image data received from Gemini");
         } catch (error: any) {
-            console.error("Gemini generation failed. Error details:", error);
+            logger.error("Gemini generation failed. Error details:", error);
             throw new Error(`Gemini generation failed: ${error.message}`);
         }
     }
@@ -72,20 +79,29 @@ export class GeminiProvider implements IAIProvider {
 
             // If the input is a URL, fetch and convert to base64
             if (imageInput.startsWith('http')) {
-                console.log("INSIDE HTTP: Image inpu starts with first 100 chars:", imageInput.substring(0, 100));
+                logger.debug(
+                    "INSIDE HTTP: Image inpu starts with first 100 chars:",
+                    imageInput.substring(0, 100)
+                );
                 const response = await axios.get(imageInput, { responseType: 'arraybuffer' });
                 const buffer = Buffer.from(response.data);
                 imageBase64 = buffer.toString('base64');
             } else {
                 // Check for and strip Data URI prefix
-                console.log("INSIDE BASE64: Image input starts with first 100 chars:", imageInput.substring(0, 100));
+                logger.debug(
+                    "INSIDE BASE64: Image input starts with first 100 chars:",
+                    imageInput.substring(0, 100)
+                );
                 const match = imageInput.match(/^data:(image\/\w+);base64,(.*)$/);
                 if (match && match[1] && match[2]) {
                     mimeType = match[1]; // Get actual mime type
                     imageBase64 = match[2]; // Get raw Base64 data
                 } else {
                     // Assume it might be raw base64 already or handle error
-                    console.log("Image input does not match Data URI format. Using as is with first 100 chars:", imageInput.substring(0, 100));
+                    logger.debug(
+                        "Image input does not match Data URI format. Using as is with first 100 chars:",
+                        imageInput.substring(0, 100)
+                    );
                     imageBase64 = imageInput;
                     // Consider logging a warning here if format is unexpected
                 }
@@ -110,12 +126,18 @@ export class GeminiProvider implements IAIProvider {
             });
 
             if (!response.candidates || response.candidates.length === 0) {
-                console.error("No candidates returned from Gemini in inpaint. Full response:", JSON.stringify(response));
+                logger.error(
+                    "No candidates returned from Gemini in inpaint. Full response:",
+                    JSON.stringify(response)
+                );
                 throw new Error("No candidates returned from Gemini");
             }
             const candidate = response.candidates[0];
             if (!candidate.content || !candidate.content.parts || candidate.content.parts.length === 0) {
-                console.error("No content parts found in Gemini candidate for inpainting. Full candidate:", JSON.stringify(candidate));
+                logger.error(
+                    "No content parts found in Gemini candidate for inpainting. Full candidate:",
+                    JSON.stringify(candidate)
+                );
                 throw new Error("No content parts found in Gemini candidate for inpainting");
             }
             for (const part of candidate.content.parts) {
@@ -125,7 +147,7 @@ export class GeminiProvider implements IAIProvider {
             }
             throw new Error("No image data received from Gemini during inpainting");
         } catch (error: any) {
-            console.error("Gemini inpainting failed. Error details:", error);
+            logger.error("Gemini inpainting failed. Error details:", error);
             throw new Error(`Gemini inpainting failed: ${error.message}`);
         }
     }

--- a/amplify/functions/providers/stabilityProvider.ts
+++ b/amplify/functions/providers/stabilityProvider.ts
@@ -1,6 +1,7 @@
 import { AIOperation, IAIProvider, ModelMetadata, ProviderMetadata } from "./IAIProvider";
 import axios from "axios";
 import FormData from "form-data";
+import logger from '../../utils/logger';
 
 // Helper function to call the resize Lambda via its Function URL stored in LAMBDA_RESIZE_URL secret
 async function callResizeLambda(base64Image: string): Promise<string> {
@@ -90,7 +91,7 @@ export class StabilityProvider implements IAIProvider {
 
             throw new Error('No image data in response: ' + JSON.stringify(response.data));
         } catch (error: any) {
-            console.error('Stability API error:', error.response?.data || error.message);
+            logger.error('Stability API error:', error.response?.data || error.message);
             throw new Error(`Stability image generation failed: ${error.message}`);
         }
     }
@@ -172,7 +173,7 @@ export class StabilityProvider implements IAIProvider {
 
             throw new Error('No image data in response');
         } catch (error: any) {
-            console.error('Stability Outpaint error:', error.response?.data || error.message);
+            logger.error('Stability Outpaint error:', error.response?.data || error.message);
             throw new Error(`Stability Outpaint failed: ${error.message}`);
         }
     }

--- a/components/StyleImageSelector.tsx
+++ b/components/StyleImageSelector.tsx
@@ -1,6 +1,7 @@
 import { list, getUrl } from 'aws-amplify/storage';
 import { fetchAuthSession } from 'aws-amplify/auth';
 import { useState, useEffect } from 'react';
+import logger from '@/utils/logger';
 import styles from "./StyleImageSelector.module.css";
 
 interface StyleImageSelectorProps {
@@ -38,7 +39,7 @@ export default function StyleImageSelector({ onSelect }: StyleImageSelectorProps
                 fetchedPhotos.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
                 setPhotos(fetchedPhotos);
             } catch (error) {
-                console.error("Error listing photos:", error);
+                logger.error("Error listing photos:", error);
             }
         };
 

--- a/components/UserPhotos.tsx
+++ b/components/UserPhotos.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react';
 import { list, getUrl } from 'aws-amplify/storage';
 import { fetchAuthSession } from 'aws-amplify/auth';
+import logger from '@/utils/logger';
 
 interface UserPhotosProps {
     onSelect: (url: string) => void;
@@ -24,7 +25,7 @@ export default function UserPhotos({ onSelect }: UserPhotosProps) {
                 );
                 setPhotos(photoData);
             } catch (error) {
-                console.error("Error loading photos:", error);
+                logger.error("Error loading photos:", error);
             }
         };
         loadPhotos();

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,50 @@
+import type { LogLevel } from '@aws-lambda-powertools/logger';
+
+// Determine log level from environment. Next.js exposes NEXT_PUBLIC_ variables to the client.
+const LOG_LEVEL = (process.env.NEXT_PUBLIC_LOG_LEVEL || process.env.LOG_LEVEL || 'INFO').toUpperCase() as LogLevel;
+
+// The logger implementation will use @aws-lambda-powertools/logger in Node
+// environments and fallback to console methods in the browser.
+
+interface LogMethods {
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
+
+let logger: LogMethods;
+
+if (typeof window === 'undefined') {
+  // Dynamically require to avoid bundling in the browser
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { Logger } = require('@aws-lambda-powertools/logger');
+  const base = new Logger({ logLevel: LOG_LEVEL });
+  logger = {
+    debug: (...args) => base.debug(...args),
+    info: (...args) => base.info(...args),
+    warn: (...args) => base.warn(...args),
+    error: (...args) => base.error(...args),
+  };
+} else {
+  const levels = ['DEBUG', 'INFO', 'WARN', 'ERROR'];
+  const shouldLog = (level: string) =>
+    levels.indexOf(level) >= levels.indexOf(LOG_LEVEL);
+
+  logger = {
+    debug: (...args) => {
+      if (shouldLog('DEBUG')) console.debug(...args);
+    },
+    info: (...args) => {
+      if (shouldLog('INFO')) console.log(...args);
+    },
+    warn: (...args) => {
+      if (shouldLog('WARN')) console.warn(...args);
+    },
+    error: (...args) => {
+      if (shouldLog('ERROR')) console.error(...args);
+    },
+  };
+}
+
+export default logger;


### PR DESCRIPTION
## Summary
- create a universal logger using `@aws-lambda-powertools/logger`
- swap console logging in components and providers for the new logger
- enable log level configuration via environment variables

## Testing
- `npm run lint` *(fails: `next` not found)*